### PR TITLE
Fix compilation and update to latest oneAPI namespaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,40 @@
-
-src/src/.DS_Store
-src/src/ops/.DS_Store
 .DS_Store
+.ipynb_checkpoints/
+
+# Project exclude paths
+cmake-build-debug/
+
+.idea
+
+# Prerequisites
+*.d
+
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Fortran module files
+*.mod
+*.smod
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app

--- a/README.md
+++ b/README.md
@@ -1,21 +1,52 @@
-### XJoin
+# XJoin
 
 XJoin implement the hash join database operator. 
 It is the DPC++ implementation of the hash join operator originally written in CUDA.
 
+## Usage
 
-##### Compile
+### On a Linux Machine
 
-```
+First compile the sources
+```bash
 mkdir build
 cd build
 cmake ..
 make
 ```
+then run the executable specifying the size of the table
 
-##### Run
+```bash
+./join <size_of_build_table>
+```
 
+### On Intel DevCloud
+
+Create a script `launch.sh` like the following one
+
+```bash
+#!/bin/sh
+echo "Starting ..."
+cd build
+cmake ..
+make
+./join <size_of_build_table>
+echo "Finished!"
 ```
-./join size_of_build_table
+
+then submit a job, for instance to a GPU worker
+
+```bash
+qsub -l nodes=1:gpu:ppn=2 -d . launch.sh
 ```
+
+Eventually, see the output in a `launch.sh.oxxxxxxx` and the (hopefully empty) error trace in `launch.sh.exxxxxxx`.
+
+**Notes:** 
+* `-l nodes=1:gpu:ppn=2` is used to assign one full GPU node to the job.
+* `-d .` is used to configure the current folder as the working directory for the task.
+* `launch.sh` is the script that gets executed on the compute node.
+* to run on a CPU, just run `qsub -d . launch.sh`
+
+
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,8 +1,23 @@
-#set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -fsycl-targets=spir64_gen-unknown-unknown-sycldevice -Xs '-device dg1'")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17 -O3 -fsycl")
+# set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3")
 
-add_executable(project src/ops/project.dp.cpp src/ops/utils/generator.h src/ops/utils/gpu_utils.h block-functions/load.dp.hpp block-functions/store.dp.hpp block-functions/crystal.dp.hpp)
-add_executable(join src/ops/join.dp.cpp src/ops/utils/generator.h src/ops/utils/gpu_utils.h block-functions/load.dp.hpp block-functions/store.dp.hpp block-functions/crystal.dp.hpp)
+add_executable(project 
+    src/ops/project.dp.cpp 
+    src/ops/utils/generator.h 
+    src/ops/utils/gpu_utils.h 
+    block-functions/load.dp.hpp 
+    block-functions/store.dp.hpp 
+    block-functions/crystal.dp.hpp
+)
+
+add_executable(join 
+    src/ops/join.dp.cpp 
+    src/ops/utils/generator.h 
+    src/ops/utils/gpu_utils.h 
+    block-functions/load.dp.hpp 
+    block-functions/store.dp.hpp 
+    block-functions/crystal.dp.hpp
+)
 
 include_directories(./)
 

--- a/src/block-functions/join.dp.hpp
+++ b/src/block-functions/join.dp.hpp
@@ -1,6 +1,6 @@
 #include <CL/sycl.hpp>
 #include <dpct/dpct.hpp>
-#include <CL/sycl/ONEAPI/atomic_ref.hpp>
+//#include <CL/sycl/ONEAPI/atomic_ref.hpp>
 #include <CL/sycl/accessor.hpp>
 
 #pragma once
@@ -8,10 +8,10 @@
 #define HASH(X,Y,Z) ((X-Z) % Y)
 
 template<typename T>
-using global_atomic_ref = sycl::ONEAPI::atomic_ref<
+using global_atomic_ref = sycl::ext::oneapi::atomic_ref<
                                 T,
-                                sycl::ONEAPI::detail::memory_order::relaxed,
-                                sycl::ONEAPI::detail::memory_scope::device,
+                                sycl::ext::oneapi::detail::memory_order::relaxed,
+                                sycl::ext::oneapi::detail::memory_scope::device,
                                 sycl::access::address_space::global_space>;
 
 

--- a/src/src/ops/join.dp.cpp
+++ b/src/src/ops/join.dp.cpp
@@ -87,7 +87,7 @@ void probe_kernel(int *fact_fkey, int *fact_val, int num_tuples,
 
     item_ct1.barrier(sycl::access::fence_space::local_space);
 
-  unsigned long long aggregate = sycl::ONEAPI::reduce(item_ct1.get_group(), sum, sycl::ONEAPI::plus<>());
+  unsigned long long aggregate = sycl::reduce_over_group(item_ct1.get_group(), sum, sycl::ext::oneapi::plus<>());
     //unsigned long long aggregate = BlockSum<long long, BLOCK_THREADS, ITEMS_PER_THREAD>(sum, (long long*)buffer, item_ct1);
 
     //item_ct1.barrier();


### PR DESCRIPTION
## Change summary
* replace deprecated `ONEAPI::atomic_ref` with `sycl::ext::oneapi::atomic_ref` (compilation error)
* replace deprecated `ONEAPI::reduce` with `sycl::reduce_over_group` (source of a cuple of deprecation warnings)
* update README to describe how to compile and run the code on Intel DevCloud
* add a more comprehensive list of directories and files to `.gitignore`
* refactor the main CMakeLists.txt